### PR TITLE
更新k8s-client创建时的参数设置

### DIFF
--- a/cmd/frps/serverconfig.go
+++ b/cmd/frps/serverconfig.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"os"
-	"path/filepath"
 
 	v1 "github.com/imneov/kube-frp/pkg/config/v1"
 	"github.com/imneov/kube-frp/pkg/k8s"
@@ -44,16 +42,6 @@ func init() {
 
 // InitManagerAndLoadConfig loads configuration from FRPServer CR
 func InitManagerAndLoadConfig(frpServerName string, kubeconfig string) (*v1.ServerConfig, error) {
-	if kubeconfig == "" {
-		kubeconfig = os.Getenv("KUBECONFIG")
-		if kubeconfig == "" {
-			home, err := os.UserHomeDir()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get user home directory: %v", err)
-			}
-			kubeconfig = filepath.Join(home, ".kube", "config")
-		}
-	}
 
 	if internetAddr == "" {
 		internetAddr = getOutboundIP().String()


### PR DESCRIPTION
### WHY

<!-- author to complete -->
如果保留这一段代码，则会造成：
k8s.NewClient方法入参一直都不为空，要么是环境变量设置的kubeconfig，要么是~/.kube/config
接下来，会导致创建client方法时，无法使用InClusterConfig创建client
因此此处需要删除这一段代码，使不输入kubeconfig时，也可以正常创建client