### PR TITLE
修复 ServiceInfo.Port int64 类型不一致导致 golangci-lint 失败

### DIFF
--- a/pkg/util/kubernetes/utils.go
+++ b/pkg/util/kubernetes/utils.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -19,12 +20,12 @@ type ServiceInfo struct {
 
 // 构造 FRP 服务名称
 func GenerateServiceName(info ServiceInfo) (string, error) {
-	if info.Protocol == "" || info.Name == "" || info.Namespace == "" || info.Cluster == "" || info.Port == "" {
+	if info.Protocol == "" || info.Name == "" || info.Namespace == "" || info.Cluster == "" || info.Port <= 0 {
 		return "", fmt.Errorf("missing required field")
 	}
 
 	// 主体部分
-	host := fmt.Sprintf("%s.%s.%s:%s", info.Name, info.Namespace, info.Cluster, info.Port)
+	host := fmt.Sprintf("%s.%s.%s:%d", info.Name, info.Namespace, info.Cluster, info.Port)
 	path := ""
 	if info.Type != "" && info.IP != "" {
 		path = fmt.Sprintf("/%s/%s", info.Type, info.IP)
@@ -61,7 +62,10 @@ func ParseServiceName(uri string) (*ServiceInfo, error) {
 	name := parts[0]
 	namespace := parts[1]
 	cluster := parts[2]
-	port := u.Port()
+	port, err := strconv.ParseInt(u.Port(), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port %q: %w", u.Port(), err)
+	}
 
 	// 路径部分
 	pathParts := strings.Split(strings.Trim(u.Path, "/"), "/")

--- a/pkg/util/kubernetes/utils_test.go
+++ b/pkg/util/kubernetes/utils_test.go
@@ -40,7 +40,6 @@ func TestGenerateServiceName(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := GenerateServiceName(tt.info)
 			if (err != nil) != tt.wantErr {
@@ -65,16 +64,23 @@ func TestParseServiceName(t *testing.T) {
 		{
 			name: "with type and ip and metadata",
 			uri:  "tcp://svc.ns.cluster:7000/pod/10.0.0.1?a=1&b=2",
-			want: &ServiceInfo{Protocol: "tcp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 7000, Type: "pod", IP: "10.0.0.1", Metadata: map[string]string{"a": "1", "b": "2"}},
+			want: &ServiceInfo{
+				Protocol: "tcp", Name: "svc", Namespace: "ns",
+				Cluster: "cluster", Port: 7000, Type: "pod", IP: "10.0.0.1",
+				Metadata: map[string]string{"a": "1", "b": "2"},
+			},
 		},
 		{
 			name: "with type and ip and metadata",
 			uri:  "udp://svc.ns.cluster:7000/pod/10.0.0.1?a=1&b=2",
-			want: &ServiceInfo{Protocol: "udp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 7000, Type: "pod", IP: "10.0.0.1", Metadata: map[string]string{"a": "1", "b": "2"}},
+			want: &ServiceInfo{
+				Protocol: "udp", Name: "svc", Namespace: "ns",
+				Cluster: "cluster", Port: 7000, Type: "pod", IP: "10.0.0.1",
+				Metadata: map[string]string{"a": "1", "b": "2"},
+			},
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseServiceName(tt.uri)
 			if (err != nil) != tt.wantErr {

--- a/pkg/util/kubernetes/utils_test.go
+++ b/pkg/util/kubernetes/utils_test.go
@@ -14,22 +14,22 @@ func TestGenerateServiceName(t *testing.T) {
 	}{
 		{
 			name: "minimal without path and metadata",
-			info: ServiceInfo{Protocol: "http", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: "80"},
+			info: ServiceInfo{Protocol: "http", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 80},
 			want: "http://svc.ns.cluster:80",
 		},
 		{
 			name: "with type only",
-			info: ServiceInfo{Protocol: "tcp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: "7000", Type: "svc"},
+			info: ServiceInfo{Protocol: "tcp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 7000, Type: "svc"},
 			want: "tcp://svc.ns.cluster:7000/svc",
 		},
 		{
 			name: "with type and IP",
-			info: ServiceInfo{Protocol: "udp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: "7000", Type: "pod", IP: "10.0.0.1"},
+			info: ServiceInfo{Protocol: "udp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 7000, Type: "pod", IP: "10.0.0.1"},
 			want: "udp://svc.ns.cluster:7000/pod/10.0.0.1",
 		},
 		{
 			name: "with metadata",
-			info: ServiceInfo{Protocol: "http", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: "80", Metadata: map[string]string{"a": "1", "b": "2"}},
+			info: ServiceInfo{Protocol: "http", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 80, Metadata: map[string]string{"a": "1", "b": "2"}},
 			want: "http://svc.ns.cluster:80?a=1&b=2",
 		},
 		{
@@ -65,12 +65,12 @@ func TestParseServiceName(t *testing.T) {
 		{
 			name: "with type and ip and metadata",
 			uri:  "tcp://svc.ns.cluster:7000/pod/10.0.0.1?a=1&b=2",
-			want: &ServiceInfo{Protocol: "tcp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: "7000", Type: "pod", IP: "10.0.0.1", Metadata: map[string]string{"a": "1", "b": "2"}},
+			want: &ServiceInfo{Protocol: "tcp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 7000, Type: "pod", IP: "10.0.0.1", Metadata: map[string]string{"a": "1", "b": "2"}},
 		},
 		{
 			name: "with type and ip and metadata",
 			uri:  "udp://svc.ns.cluster:7000/pod/10.0.0.1?a=1&b=2",
-			want: &ServiceInfo{Protocol: "udp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: "7000", Type: "pod", IP: "10.0.0.1", Metadata: map[string]string{"a": "1", "b": "2"}},
+			want: &ServiceInfo{Protocol: "udp", Name: "svc", Namespace: "ns", Cluster: "cluster", Port: 7000, Type: "pod", IP: "10.0.0.1", Metadata: map[string]string{"a": "1", "b": "2"}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## 背景

golangci-lint CI 失败：https://github.com/tkeel-io/kube-frp/actions/runs/28242944133/job/83674287372

> 注：tkeel-io / wuxs / edgewize-io 三个仓库均已禁用 issues，无法创建关联 issue，本 PR 承载完整任务上下文。

## WHY

`pkg/util/kubernetes/utils.go` 中 `ServiceInfo.Port` 字段定义为 `int64`，但所有用法仍按 `string` 处理，golangci-lint `typecheck` 失败（8 处）：

- `GenerateServiceName`：`info.Port == ""`（int64 与 string 比较）、`fmt.Sprintf("...:%s", ..., info.Port)`
- `ParseServiceName`：将 `u.Port()`（string）直接赋给 `Port`
- `utils_test.go`：端口字面量传 `"80"` / `"7000"`

## 变更

**1. Port 类型用法修复**（保持 `Port int64` 不变，`ServiceInfo` 无外部调用方，改动仅限该包）：

| 文件 | 改动 |
|------|------|
| `utils.go` | 判空 `== ""` → `<= 0`；端口格式化 `%s` → `%d` |
| `utils.go` | `ParseServiceName` 用 `strconv.ParseInt` 解析 URL 端口，解析失败返回 error |
| `utils_test.go` | 6 处端口字面量 `"80"` / `"7000"` → `80` / `7000` |

**2. 本文件 lint 清理**（让 utils.go/utils_test.go 符合 `.golangci.yml` 启用的全部 linter）：

| 文件 | 改动 |
|------|------|
| `utils_test.go` | 删除冗余 `tt := tt`（copyloopvar）；拆分超长 `want` 字面量 179 字符 → 多行（lll 上限 160） |

## 验证

本地用与 CI 完全一致的环境（go 1.23.12 + golangci-lint v1.61.0）验证：

```
golangci-lint run ./pkg/util/kubernetes/...   # 退出码 0，两文件 0 问题
go test ./pkg/util/kubernetes/...             # ok 0.003s
gofmt -l pkg/util/kubernetes/                 # 空
```

## 范围说明（重要）

typecheck 修复后，CI 首次完整跑通 lint，暴露出 **dev 分支全仓库约 40 处预存 lint 债务**（gci 导入排序、gofumpt、unused 死代码、deprecated API 等），主要集中在 K8s 集成代码（`pkg/k8s/`、`server/operator.go`、`cmd/frps/root.go`），与本 PR 的 Port 修复**无关**——此前因 typecheck 一直失败，这些 lint 从未真正跑过。

按约定本 PR **仅保证 utils.go/utils_test.go 两个文件 lint-clean**，不清理全仓库债务。因此：

- 本 PR 的 CI 仍会因上述全仓库预存债务而 **fail**；
- 建议另开独立 chore PR 专门清理全仓库 lint 债务。

## 风险

- `ParseServiceName` 行为收紧：URL 端口非整数时现在返回 error（原先静默存入字符串）。合理修正，当前无调用方受影响。
